### PR TITLE
workaround for 163 blocking overseas ip (needs more testing on reliability)

### DIFF
--- a/zhuaxia/netease.py
+++ b/zhuaxia/netease.py
@@ -17,7 +17,7 @@ LOG = log.get_logger("zxLogger")
 
 #163 music api url
 url_163="http://music.163.com"
-url_mp3="http://m1.music.126.net/%s/%s.mp3"
+url_mp3="http://m5.music.126.net/%s/%s.mp3"
 url_album="http://music.163.com/api/album/%s/"
 url_song="http://music.163.com/api/song/detail/?id=%s&ids=[%s]"
 url_playlist="http://music.163.com/api/playlist/detail?id=%s"


### PR DESCRIPTION
With this change, overseas ip's can access songs again (not tested extensively though, so im not sure if this is safe to use), however it is very likely that 163 will change this behaviour soon.