### PR TITLE
Add `-m` to save meta info `~/.zhuxia/zhuxia.metadb`, without writing ID3 tags to mp3 files.

### DIFF
--- a/zhuaxia/config.py
+++ b/zhuaxia/config.py
@@ -1,4 +1,4 @@
-from os import path 
+from os import path
 import os
 import shutil, sys
 import ConfigParser
@@ -13,6 +13,7 @@ SAMPLE_CONF = path.join(PKG_PATH, 'conf','default.conf')
 SAMPLE_DB   = path.join(PKG_PATH, 'conf','default.history')
 CONF_FILE   = path.join(USER_PATH, "zhuaxia.conf")
 HIST_DB     = path.join(USER_PATH, "history.data")
+META_DB_FILE = path.join(USER_PATH, "zhuaxia.metadb")
 
 
 ######user config####
@@ -26,7 +27,7 @@ THREAD_POOL_SIZE     = 3
 DOWNLOAD_DIR         = '/tmp'
 SHOW_DONE_NUMBER     = 5
 
-#here check topx, if the value <= 0, there is no upper-bound 
+#here check topx, if the value <= 0, there is no upper-bound
 DOWNLOAD_TOP_SONG    = 10
 
 #a variable name dict for dynamic assignment
@@ -64,7 +65,7 @@ def load_single_config(conf_parser, conf_key):
             log.warn(config_warn_msg % (conf_key, str(globals()[var_dict[conf_key][0]])))
 
 def load_config():
-    
+
     # if conf file doesn't exist, cp default conf there
     if not path.exists(CONF_FILE):
         init_config()

--- a/zhuaxia/config.py
+++ b/zhuaxia/config.py
@@ -14,6 +14,7 @@ SAMPLE_DB   = path.join(PKG_PATH, 'conf','default.history')
 CONF_FILE   = path.join(USER_PATH, "zhuaxia.conf")
 HIST_DB     = path.join(USER_PATH, "history.data")
 META_DB_FILE = path.join(USER_PATH, "zhuaxia.metadb")
+META_DB_JSON = path.join(USER_PATH, "zhuaxia_metadb.json")
 
 
 ######user config####

--- a/zhuaxia/i18n/msg_cn.py
+++ b/zhuaxia/i18n/msg_cn.py
@@ -10,14 +10,14 @@ fmt_summary_success_header       = u'歌曲名\t保存路径'
 fmt_summary_failed_title         = u'失败下载列表:'
 fmt_summary_failed_header        = u'歌曲名\t保存路径'
 summary_prompt                   = u'(q)退出/(v)查看下载报告/(s)保存下载报告. 请输入 [q/v/s]:'
-summary_prompt_err               = u" 无效输入\n" 
-summary_saved                    = u" 下载报告保存于: %s" 
+summary_prompt_err               = u" 无效输入\n"
+summary_saved                    = u" 下载报告保存于: %s"
 
-history_clear_confirm            = u" 找到 %d 条下载记录, 确认要清空所有下载历史记录? [y/n]" 
-history_clearing                 = u" 忽略其它选项,清空zhuaxia下载历史记录..." 
-history_cleared                  = u" zhuaxia所有下载记录已清空" 
-history_exporting                = u" 忽略其它选项, 正在导出下载历史记录..." 
-history_exported                 = u" 下载历史记录导出到: %s" 
+history_clear_confirm            = u" 找到 %d 条下载记录, 确认要清空所有下载历史记录? [y/n]"
+history_clearing                 = u" 忽略其它选项,清空zhuaxia下载历史记录..."
+history_cleared                  = u" zhuaxia所有下载记录已清空"
+history_exporting                = u" 忽略其它选项, 正在导出下载历史记录..."
+history_exported                 = u" 下载历史记录导出到: %s"
 
 fmt_insert_hist                  = u' 为成功下载建立历史记录...'
 fmt_all_finished                 = u' 所有任务都已完成'
@@ -72,7 +72,7 @@ fmt_links_in_file                = u' 文件包含链接总数: %d'
 
 experimental                     = u'-p 选项为实验性选项. 自动获取代理服务器池解析/下载。因代理服务器稳定性未知，下载可能会慢或不稳定。'
 ver_text                         = u'zhuaxia (抓虾) '
-help_info                        = u""" 
+help_info                        = u"""
     zhuaxia (抓虾) -- 抓取[虾米音乐]和[网易云音乐]的 mp3 音乐
 
     [CONFIG FILE:] $HOME/.zhuaxia/zhuaxia.conf
@@ -90,6 +90,8 @@ help_info                        = u"""
 
         -h : 显示帮助
 
+        -m : （仅适用于）网易云音乐不写入 ID3 标签，保存详细信息到 ~/.zhuaxia/zhuxia.db
+
         -l : 下载歌曲的lrc格式歌词
 
         -f : 从文件下载
@@ -102,7 +104,7 @@ help_info                        = u"""
              如果这个选项被使用, 其它选项将被忽略
 
         -d : 清空当前下载历史记录
-             如果这个选项被使用, 其它选项将被忽略. 
+             如果这个选项被使用, 其它选项将被忽略.
              -e 和-d 选项不能同时使用
 
         -v : 显示版本信息
@@ -145,7 +147,7 @@ help_info                        = u"""
                     zx -d
 
     [AUTHOR]
-        
+
         Kai Yuan <kent.yuan(at)gmail.com>
         please report bugs or feature requests at https://github.com/sk1418/zhuaxia/issues
         """

--- a/zhuaxia/i18n/msg_cn.py
+++ b/zhuaxia/i18n/msg_cn.py
@@ -92,6 +92,9 @@ help_info                        = u"""
 
         -m : （仅适用于）网易云音乐不写入 ID3 标签，保存详细信息到 ~/.zhuaxia/zhuxia.db
 
+        -j : 导出音乐元数据库为 JSON 文件 (~/.zhuaxia/zhuaxia_metadb.json)
+             如果这个选项被使用, 其它选项将被忽略
+
         -l : 下载歌曲的lrc格式歌词
 
         -f : 从文件下载

--- a/zhuaxia/i18n/msg_en.py
+++ b/zhuaxia/i18n/msg_en.py
@@ -10,14 +10,14 @@ fmt_summary_success_header       = u'Name\tLocation'
 fmt_summary_failed_title         = u'Failed Downloadings:'
 fmt_summary_failed_header        = u'Name\tLocation'
 summary_prompt                   = u'(q)uit/(v)iew summary/(s)ave summary. Please input [q/v/s]:'
-summary_prompt_err               = u"Invalid input.\n" 
-summary_saved                    = u" summary was saved at: %s" 
+summary_prompt_err               = u"Invalid input.\n"
+summary_saved                    = u" summary was saved at: %s"
 
-history_clear_confirm            = u" %d downloading histories found. Are you sure to remove all these histories? [y/n]" 
-history_clearing                 = u" Clear zhuaxia downloading hisotory (other options will be ignored)" 
-history_cleared                  = u" All zhuaxia download history has been cleared." 
-history_exporting                = u" Exporting download history (other options will be ignored)..." 
-history_exported                 = u" Zhuaxia download-history was exported to: %s" 
+history_clear_confirm            = u" %d downloading histories found. Are you sure to remove all these histories? [y/n]"
+history_clearing                 = u" Clear zhuaxia downloading hisotory (other options will be ignored)"
+history_cleared                  = u" All zhuaxia download history has been cleared."
+history_exporting                = u" Exporting download history (other options will be ignored)..."
+history_exported                 = u" Zhuaxia download-history was exported to: %s"
 
 fmt_all_finished                 = u' All jobs are finished.'
 fmt_insert_hist                  = u' Recording history for successful downloads...'
@@ -71,7 +71,7 @@ fmt_links_in_file                = u' file contains urls: %d'
 
 experimental                     = u'-p is an experimental option. Auto fetching proxy from proxy pool. Downloading could be slow or unstable due to the unknown proxy status.'
 ver_text                         = u'zhuaxia '
-help_info                        = u""" 
+help_info                        = u"""
     zhuaxia -- download mp3 music from [xiami.com] and [music.163.com]
 
     [CONFIG FILE:]  $HOME/.zhuaxia/zhuaxia.conf
@@ -87,6 +87,8 @@ help_info                        = u"""
                 - no special requirement
 
         -h : show this help
+
+        -m : (NetEase only) does not write ID3 tags to file, instead write meta data to ~/.zhuaxia/zhuxia.db
 
         -l : download lyric too (lrc format)
 
@@ -136,10 +138,10 @@ help_info                        = u"""
 
         Other Examples:
 
-                download lyrics with songs: 
+                download lyrics with songs:
                     zx -l "http://music.163.com/song?id=27552647"
 
-                incremental download songs with lyrics: 
+                incremental download songs with lyrics:
                     zx -li "http://music.163.com/song?id=27552647"
 
                 export zhuaxia download history. File will be save under "download.dir" in config file:
@@ -147,9 +149,9 @@ help_info                        = u"""
 
                 clear(delete) all zhuaxia download history:
                     zx -d
-                
+
     [AUTHOR]
-        
+
         Kai Yuan <kent.yuan(at)gmail.com>
         please report bugs or feature requests at https://github.com/sk1418/zhuaxia/issues
         """

--- a/zhuaxia/i18n/msg_en.py
+++ b/zhuaxia/i18n/msg_en.py
@@ -90,6 +90,8 @@ help_info                        = u"""
 
         -m : (NetEase only) does not write ID3 tags to file, instead write meta data to ~/.zhuaxia/zhuxia.db
 
+        -j : export metadb to JSON (~/.zhuaxia/zhuaxia_metadb.json), if this option is given, other options will be ignored.
+
         -l : download lyric too (lrc format)
 
         -f : download from url file (see example in [USAGE])

--- a/zhuaxia/netease.py
+++ b/zhuaxia/netease.py
@@ -39,8 +39,8 @@ pubKey = '010001'
 
 class NeteaseSong(Song):
     """
-    163 Song class, if song_json was given, 
-    Song.post_set() needs to be called for post-setting 
+    163 Song class, if song_json was given,
+    Song.post_set() needs to be called for post-setting
     abs_path, filename, etc.
     url example: http://music.163.com/song?id=209235
     """
@@ -70,6 +70,9 @@ class NeteaseSong(Song):
     def init_by_json(self,js):
         #song_id
         self.song_id = js['id']
+        # meta
+        if self.handler.need_detail:
+            self.json = js
         #name
         self.song_name = util.decode_html(js['name'])
         LOG.debug("parsing song %s ...."%self.song_name)
@@ -119,7 +122,7 @@ class NeteaseAlbum(object):
         """url example: http://music.163.com/album?id=2646379"""
 
         self.handler=m163
-        self.url = url 
+        self.url = url
         self.album_id = re.search(r'(?<=/album\?id=)\d+', self.url).group(0)
         LOG.debug(msg.head_163 + msg.fmt_init_album % self.album_id)
         self.year = None
@@ -211,6 +214,7 @@ class Netease(Handler):
     def __init__(self, option):
         Handler.__init__(self,option.proxies)
         self.is_hq = option.is_hq
+        self.need_detail = option.need_detail
         self.dl_lyric = option.dl_lyric
         #headers
         self.HEADERS = {'User-Agent':AGENT}
@@ -218,7 +222,7 @@ class Netease(Handler):
         self.HEADERS['Cookie'] = 'appver=1.7.3'
 
     def read_link(self, link):
-        
+
         retVal = None
         requests_proxy = {}
         if config.CHINA_PROXY_HTTP:
@@ -229,7 +233,7 @@ class Netease(Handler):
             while True:
                 try:
                     retVal =  requests.get(link, headers=self.HEADERS, proxies=requests_proxy)
-                    break 
+                    break
                 except requests.exceptions.ConnectionError:
                     LOG.debug('invalid proxy detected, removing from pool')
                     self.proxies.del_proxy(requests_proxy['http'])
@@ -285,6 +289,6 @@ class Netease(Handler):
             r = self.read_link(result)
             if r.history:
                 return  r.history[0].headers['Location']
-        
+
         return result
 

--- a/zx
+++ b/zx
@@ -6,6 +6,8 @@ import sys
 #load config at very beginning
 config.load_config()
 
+import marshal
+import json
 import sys,getopt
 import zhuaxia.util as util
 import logging
@@ -56,6 +58,25 @@ def export_or_clear_hist(export_hist, empty_hist):
                 hist_handler.empty_hists()
                 sys.exit(0)
 
+def to_json(thing, f):
+    """dump to JSON file"""
+    json.dump(thing, open(f, 'w'))
+
+def marshal_load_iter(f):
+    while True:
+        try:
+            yield marshal.load(f)
+        except EOFError:
+            return
+
+def metadb_to_json():
+    """Convert metadb to JSON file."""
+    songs = []
+    with open(config.META_DB_FILE, 'rb') as f:
+        for song in marshal_load_iter(f):
+            songs.append(song)
+    to_json(songs, config.META_DB_JSON)
+
 if __name__ == '__main__':
     log.setup_log(logger_name, config.LOG_LVL_CONSOLE, config.LOG_LVL_FILE)
     LOG = log.get_logger(logger_name)
@@ -73,7 +94,7 @@ if __name__ == '__main__':
 
         if len(sys.argv)<2: raise getopt.GetoptError("parameters are missing...")
 
-        opts, args = getopt.getopt(sys.argv[1:],":f:Hhvpmlied")
+        opts, args = getopt.getopt(sys.argv[1:],":f:Hhvpmliedj")
         for o, a in opts:
             if o == '-h':
                 usage()
@@ -98,6 +119,10 @@ if __name__ == '__main__':
                 export_hist = True
             elif o == '-d': #empty history
                 empty_hist = True
+            elif o == '-j': # export metadb to json
+                metadb_to_json()
+                sys.exit(0)
+
 
         #handle the export and empty
         export_or_clear_hist(export_hist, empty_hist)

--- a/zx
+++ b/zx
@@ -59,12 +59,13 @@ def export_or_clear_hist(export_hist, empty_hist):
 if __name__ == '__main__':
     log.setup_log(logger_name, config.LOG_LVL_CONSOLE, config.LOG_LVL_FILE)
     LOG = log.get_logger(logger_name)
-    
+
     try:
         hq             = False
         inFile         = ''
         inUrl          = ''
         needProxyPool  = False
+        need_detail    = False
         dl_lyric       = False
         incremental_dl = False
         export_hist    = False
@@ -72,7 +73,7 @@ if __name__ == '__main__':
 
         if len(sys.argv)<2: raise getopt.GetoptError("parameters are missing...")
 
-        opts, args = getopt.getopt(sys.argv[1:],":f:Hhvplied")
+        opts, args = getopt.getopt(sys.argv[1:],":f:Hhvpmlied")
         for o, a in opts:
             if o == '-h':
                 usage()
@@ -87,6 +88,8 @@ if __name__ == '__main__':
             elif o == '-p':
                 LOG.warning(msg.experimental)
                 needProxyPool = True
+            elif o == '-m':
+                need_detail = True
             elif o == '-l':
                 dl_lyric = True
             elif o == '-i':
@@ -95,8 +98,8 @@ if __name__ == '__main__':
                 export_hist = True
             elif o == '-d': #empty history
                 empty_hist = True
-        
-        #handle the export and empty 
+
+        #handle the export and empty
         export_or_clear_hist(export_hist, empty_hist)
 
         ## -f check file
@@ -110,6 +113,7 @@ if __name__ == '__main__':
         option = user_option.Option()
         option.is_hq = hq
         option.need_proxy_pool = needProxyPool
+        option.need_detail = need_detail
         option.dl_lyric = dl_lyric
         option.inFile = inFile
         option.inUrl = inUrl
@@ -120,7 +124,7 @@ if __name__ == '__main__':
 
         # ok, let's go!
         commander.shall_I_begin(option)
-                
+
     except getopt.GetoptError as e:
         LOG.error(str(e))
         print log.hl("\nTo know how to use zhuaxia, run:\n\tzx -h\n",'cyan')


### PR DESCRIPTION
Currently only 163 music is supported,
since I do not use Xiami music.

And `-j` to export to a json file.

I implement this option
because I have downloaded too many mp3 files to fit my SSD.
I moved most of them to an external hard disk,
but I still want to keep all meta info on my SSD.